### PR TITLE
fix:修复ESP32S3无法正常使用所有DVP摄像头 (AEGHB-1269)

### DIFF
--- a/esp_cam_sensor/sensors/bf3925/Kconfig.bf3925
+++ b/esp_cam_sensor/sensors/bf3925/Kconfig.bf3925
@@ -1,7 +1,7 @@
 menuconfig CAMERA_BF3925
     bool "BF3925"
     default n
-    depends on SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_LCDCAM_SUPPORTED
     help
         Enable support for the BF3925 CMOS image sensor.
 

--- a/esp_cam_sensor/sensors/bf3a03/Kconfig.bf3a03
+++ b/esp_cam_sensor/sensors/bf3a03/Kconfig.bf3a03
@@ -1,7 +1,7 @@
 menuconfig CAMERA_BF3A03
     bool "BF3A03"
     default n
-    depends on SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_LCDCAM_SUPPORTED
     help
         Enable support for the BF3A03 CMOS image sensor.
 

--- a/esp_cam_sensor/sensors/gc0308/Kconfig.gc0308
+++ b/esp_cam_sensor/sensors/gc0308/Kconfig.gc0308
@@ -1,7 +1,7 @@
 menuconfig CAMERA_GC0308
     bool "GC0308"
     default n
-    depends on SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_LCDCAM_SUPPORTED
     help
         Enable support for the GC0308 CMOS image sensor.
 

--- a/esp_cam_sensor/sensors/gc2145/Kconfig.gc2145
+++ b/esp_cam_sensor/sensors/gc2145/Kconfig.gc2145
@@ -1,7 +1,7 @@
 menuconfig CAMERA_GC2145
     bool "GC2145"
     default n
-    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_SUPPORTED
     help
         Enable support for the GC2145 CMOS image sensor.
 
@@ -10,7 +10,7 @@ if CAMERA_GC2145
         config CAMERA_GC2145_AUTO_DETECT_DVP_INTERFACE_SENSOR
             bool "Detect for DVP interface sensor"
             default n
-            depends on SOC_LCDCAM_CAM_SUPPORTED
+            depends on SOC_LCDCAM_SUPPORTED
             help
                 When enabled, the GC2145 sensor will be automatically detected
                 and initialized on the DVP interface at startup without requiring
@@ -66,7 +66,7 @@ if CAMERA_GC2145
     choice CAMERA_GC2145_DVP_DEFAULT_FMT
         prompt "Select default output format for DVP interface"
         default CAMERA_GC2145_DVP_RGB565_640X480_15FPS
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         help
             Select the default video format to use when the sensor initializes on DVP interface.
             Format can be changed at runtime when streaming is stopped.
@@ -90,7 +90,7 @@ if CAMERA_GC2145
 
     config CAMERA_GC2145_DVP_IF_FORMAT_INDEX_DEFAULT
         int
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         default 0 if CAMERA_GC2145_DVP_RGB565_640X480_15FPS
         default 1 if CAMERA_GC2145_DVP_RGB565_1600X1200_13FPS
         default 2 if CAMERA_GC2145_DVP_RGB565_800X600_20FPS

--- a/esp_cam_sensor/sensors/ov2640/Kconfig.ov2640
+++ b/esp_cam_sensor/sensors/ov2640/Kconfig.ov2640
@@ -1,7 +1,7 @@
 menuconfig CAMERA_OV2640
     bool "OV2640"
     default n
-    depends on SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_LCDCAM_SUPPORTED
     help
         Enable support for the OV2640 CMOS image sensor.
 

--- a/esp_cam_sensor/sensors/ov3660/Kconfig.ov3660
+++ b/esp_cam_sensor/sensors/ov3660/Kconfig.ov3660
@@ -1,7 +1,7 @@
 menuconfig CAMERA_OV3660
     bool "OV3660"
     default n
-    depends on SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_LCDCAM_SUPPORTED
     help
         Enable support for the OV3660 CMOS image sensor.
 

--- a/esp_cam_sensor/sensors/ov5640/Kconfig.ov5640
+++ b/esp_cam_sensor/sensors/ov5640/Kconfig.ov5640
@@ -1,7 +1,7 @@
 menuconfig CAMERA_OV5640
     bool "OV5640"
     default n
-    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_SUPPORTED
     help
         Enable support for the OV5640 CMOS image sensor.
 
@@ -10,7 +10,7 @@ if CAMERA_OV5640
         config CAMERA_OV5640_AUTO_DETECT_DVP_INTERFACE_SENSOR
             bool "Detect for DVP interface sensor"
             default n
-            depends on SOC_LCDCAM_CAM_SUPPORTED
+            depends on SOC_LCDCAM_SUPPORTED
             help
                 When enabled, the OV5640 sensor will be automatically detected
                 and initialized on the DVP interface at startup without requiring
@@ -54,7 +54,7 @@ if CAMERA_OV5640
     choice CAMERA_OV5640_DVP_DEFAULT_FMT
         prompt "Select default output format for DVP interface"
         default CAMERA_OV5640_DVP_YUV422_800X600_10FPS
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         help
             This option allows you to select the default video format for the OV5640 sensor
             when it is initialized on the DVP interface. The selected format will be used
@@ -70,7 +70,7 @@ if CAMERA_OV5640
 
     config CAMERA_OV5640_DVP_IF_FORMAT_INDEX_DEFAULT
         int
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         default 0 if CAMERA_OV5640_DVP_YUV422_800X600_10FPS
         help
             Sets the default configuration for the DVP interface.

--- a/esp_cam_sensor/sensors/sc030iot/Kconfig.sc030iot
+++ b/esp_cam_sensor/sensors/sc030iot/Kconfig.sc030iot
@@ -1,7 +1,7 @@
 menuconfig CAMERA_SC030IOT
     bool "SC030IOT"
     default n
-    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_SUPPORTED
     help
         Enable support for the SC030IOT CMOS image sensor.
 
@@ -10,7 +10,7 @@ if CAMERA_SC030IOT
         config CAMERA_SC030IOT_AUTO_DETECT_DVP_INTERFACE_SENSOR
             bool "Detect for DVP interface sensor"
             default y
-            depends on SOC_LCDCAM_CAM_SUPPORTED
+            depends on SOC_LCDCAM_SUPPORTED
             help
                 When enabled, the SC030IOT sensor will be automatically detected
                 and initialized on the DVP interface at startup without requiring
@@ -29,7 +29,7 @@ if CAMERA_SC030IOT
     choice CAMERA_SC030IOT_DVP_DEFAULT_FMT
         prompt "Select default output format for DVP interface"
         default CAMERA_SC030IOT_DVP_YUV422_640X480_26FPS
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         help
             This option allows you to select the default video format for the SC030IOT sensor
             when it is initialized on the DVP interface. The selected format will be used
@@ -50,7 +50,7 @@ if CAMERA_SC030IOT
 
     config CAMERA_SC030IOT_DVP_IF_FORMAT_INDEX_DEFAULT
         int
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         default 0 if CAMERA_SC030IOT_DVP_YUV422_640X480_26FPS
         default 1 if CAMERA_SC030IOT_DVP_RAW8_640X480_26FPS
         help

--- a/esp_cam_sensor/sensors/sc101iot/Kconfig.sc101iot
+++ b/esp_cam_sensor/sensors/sc101iot/Kconfig.sc101iot
@@ -1,7 +1,7 @@
 menuconfig CAMERA_SC101IOT
     bool "SC101IOT"
     default n
-    depends on SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_LCDCAM_SUPPORTED
     help
         Enabling this option will add the support for SC101IOT.
 

--- a/esp_cam_sensor/sensors/sc2336/Kconfig.sc2336
+++ b/esp_cam_sensor/sensors/sc2336/Kconfig.sc2336
@@ -1,7 +1,7 @@
 menuconfig CAMERA_SC2336
     bool "SC2336"
     default n
-    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_CAM_SUPPORTED
+    depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_SUPPORTED
     help
         Enable support for the SC2336 CMOS image sensor.
 
@@ -10,7 +10,7 @@ if CAMERA_SC2336
         config CAMERA_SC2336_AUTO_DETECT_DVP_INTERFACE_SENSOR
             bool "Detect for DVP interface sensor"
             default n
-            depends on SOC_LCDCAM_CAM_SUPPORTED
+            depends on SOC_LCDCAM_SUPPORTED
             help
                 When enabled, the SC2336 sensor will be automatically detected
                 and initialized on the DVP interface at startup without requiring
@@ -123,7 +123,7 @@ if CAMERA_SC2336
     choice CAMERA_SC2336_DVP_DEFAULT_FMT
         prompt "Select default output format for DVP interface"
         default CAMERA_SC2336_DVP_RAW10_1280X720_30FPS
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         help
             This option allows you to select the default video format for the SC2336 sensor
             when it is initialized on the DVP interface. The selected format will be used
@@ -139,7 +139,7 @@ if CAMERA_SC2336
 
     config CAMERA_SC2336_DVP_IF_FORMAT_INDEX_DEFAULT
         int
-        depends on SOC_LCDCAM_CAM_SUPPORTED
+        depends on SOC_LCDCAM_SUPPORTED
         default 0 if CAMERA_SC2336_DVP_RAW10_1280X720_30FPS
         help
             Sets the configuration loaded by default for the DVP interface.


### PR DESCRIPTION
目前使用ESP32S3的时候，menuconfig中DVP摄像头只显示了BF3901，但其他各种DVP摄像头也应该支持的