### PR TITLE
fix bug (AEGHB-1270)

### DIFF
--- a/esp_video/CHANGELOG.md
+++ b/esp_video/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+- Fix array bounds check failure in destroy_sccb_device() when compile option is PTIMIZATION_SIZE
+
 ## 1.3.0
 
 - Add RISC-V software swap byte function for DVP video device

--- a/esp_video/idf_component.yml
+++ b/esp_video/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.0"
+version: "1.3.1"
 description: A framework designed to support Linux V4L2, multiple cameras and video streaming.
 targets:
   - esp32p4

--- a/esp_video/src/esp_video_init.c
+++ b/esp_video/src/esp_video_init.c
@@ -293,8 +293,9 @@ static void destroy_sccb_device(esp_sccb_io_handle_t handle, esp_video_init_sccb
                 mark[i2c_port].handle = NULL;
 
                 s_sensor_sccb_mask[i2c_port].handle = NULL;
-                s_sensor_sccb_mask[i2c_port].sccb_io[0] = NULL;
-                s_sensor_sccb_mask[i2c_port].sccb_io[1] = NULL;
+                for (int j = 0; j < ESP_VIDEO_INIT_DEV_NUMS; j++) {
+                    s_sensor_sccb_mask[i2c_port].sccb_io[j] = NULL;
+                }
             }
         }
     } else {


### PR DESCRIPTION
esp_video组件存在数组越界Bug：// 错误的代码（第296-297行）
s_sensor_sccb_mask[i2c_port].sccb_io[0] = NULL;
s_sensor_sccb_mask[i2c_port].sccb_io[1] = NULL;  // ❌ 数组越界！ 问题分析：
sccb_io 数组大小定义为 ESP_VIDEO_INIT_DEV_NUMS
这是一个枚举值，取决于启用的视频设备数量
您只启用了DVP设备，所以 ESP_VIDEO_INIT_DEV_NUMS = 1
数组只有 sccb_io[0]，但代码试图访问 sccb_io[1]
GCC的 -Werror=array-bounds 检测到越界访问并报错
🔧 修复内容
// 修复后的代码（第296-298行）
s_sensor_sccb_mask[i2c_port].handle = NULL;
for (int j = 0; j < ESP_VIDEO_INIT_DEV_NUMS; j++) {
    s_sensor_sccb_mask[i2c_port].sccb_io[j] = NULL;
}
将硬编码的数组访问改为循环：
这样无论 ESP_VIDEO_INIT_DEV_NUMS 的值是多少（1、2、3...），代码都能正确工作。
