### PR TITLE
feat(sc121at)support new 1280x960 30fps config (AEGHB-1619)

### DIFF
--- a/esp_cam_sensor/sensors/sc121at/Kconfig.sc121at
+++ b/esp_cam_sensor/sensors/sc121at/Kconfig.sc121at
@@ -3,7 +3,7 @@ menuconfig CAMERA_SC121AT
     default n
     depends on SOC_MIPI_CSI_SUPPORTED || SOC_LCDCAM_CAM_SUPPORTED
     help
-        Enable support for the SC121AT CMOS image sensor. 
+        Enable support for the SC121AT CMOS image sensor.
 
 if CAMERA_SC121AT
     menu "Auto detect SC121AT"
@@ -33,12 +33,17 @@ if CAMERA_SC121AT
             default y
             help
                 YUV422(UYVY) color format at 1280x800 resolution with 25fps framerate.
+        config CAMERA_SC121AT_MIPI_YUV422_1280X960_30FPS
+            bool "MIPI 2-lane, 24M input, 1280x960  30fps, YUV422(UYVY)"
+            default y
+            help
+                YUV422(UYVY) color format at 1280x960 resolution with 30fps framerate.
     endmenu
 
     choice CAMERA_SC121AT_MIPI_DEFAULT_FMT
         prompt "Select default output format for MIPI CSI interface"
         depends on SOC_MIPI_CSI_SUPPORTED
-        default CAMERA_SC121AT_MIPI_DEFAULT_FMT_YUV422_1280X800_25FPS
+        default CAMERA_SC121AT_MIPI_DEFAULT_FMT_YUV422_1280X960_30FPS
         help
             This option allows you to select the default video format for the SC121AT sensor
             when it is initialized on the MIPI CSI interface. The selected format will be used
@@ -48,6 +53,9 @@ if CAMERA_SC121AT
         config CAMERA_SC121AT_MIPI_DEFAULT_FMT_YUV422_1280X800_25FPS
             bool "MIPI 2-lane, 24M input, 1280x800  25fps, YUV422(UYVY)"
             depends on CAMERA_SC121AT_MIPI_YUV422_1280X800_25FPS
+        config CAMERA_SC121AT_MIPI_DEFAULT_FMT_YUV422_1280X960_30FPS
+            bool "MIPI 2-lane, 24M input, 1280x960  30fps, YUV422(UYVY)"
+            depends on CAMERA_SC121AT_MIPI_YUV422_1280X960_30FPS
 
     endchoice # CAMERA_SC121AT_MIPI_DEFAULT_FMT
 
@@ -55,6 +63,7 @@ if CAMERA_SC121AT
         int
         depends on SOC_MIPI_CSI_SUPPORTED
         default 0 if CAMERA_SC121AT_MIPI_DEFAULT_FMT_YUV422_1280X800_25FPS
+        default 1 if CAMERA_SC121AT_MIPI_DEFAULT_FMT_YUV422_1280X960_30FPS
         help
             Sets the default configuration for the MIPI CSI interface.
             Use query_support_formats() API to get more format options.

--- a/esp_cam_sensor/sensors/sc121at/private_include/sc121at_mipi_2lane_24Minput_1280x960_yuv422_uyvy_30fps.h
+++ b/esp_cam_sensor/sensors/sc121at/private_include/sc121at_mipi_2lane_24Minput_1280x960_yuv422_uyvy_30fps.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Shenzhen ALG-TECH Co., Ltd.,
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+static const sc121at_reginfo_t sc121at_mipi_2lane_24Minput_1280x960_yuv422_30fps[] = {
+    /* MIPI_2lane(YUV422) 1280x800,25fps */
+    /* MIPI data rate is 448 Mbps/lane */
+    {0x3222,0x00},
+    {0x500f,0x30},
+    {SC121AT_REG_END, 0x00},
+};
+
+

--- a/esp_cam_sensor/sensors/sc121at/private_include/sc121at_settings.h
+++ b/esp_cam_sensor/sensors/sc121at/private_include/sc121at_settings.h
@@ -18,8 +18,10 @@ extern "C" {
 #define SC121AT_SOFT_POWER_DOWN_EN                 (0x01)
 #define SC121AT_OUTPUT_ENABLE_DEFAULT              (0)
 #define SC121AT_IDI_CLOCK_RATE_1280x800_25FPS      (59000000ULL)
+#define SC121AT_IDI_CLOCK_RATE_1280x960_30FPS      (59000000ULL)
 // Note, all clock configurations default to using 2 data lane mode, so use bitwidth divide by 2
 #define SC121AT_LINE_RATE_16BITS_1280x800_25FPS     (SC121AT_IDI_CLOCK_RATE_1280x800_25FPS * 8)
+#define SC121AT_LINE_RATE_16BITS_1280x960_30FPS     (SC121AT_IDI_CLOCK_RATE_1280x960_30FPS * 8)
 
 #if CONFIG_SOC_MIPI_CSI_SUPPORTED
 
@@ -42,6 +44,7 @@ static const sc121at_reginfo_t sc121at_mipi_stream_off[] = {
 };
 
 #include "sc121at_mipi_2lane_24Minput_1280x800_yuv422_uyvy_25fps.h"
+#include "sc121at_mipi_2lane_24Minput_1280x960_yuv422_uyvy_30fps.h"
 
 #endif
 

--- a/esp_cam_sensor/sensors/sc121at/sc121at.c
+++ b/esp_cam_sensor/sensors/sc121at/sc121at.c
@@ -40,6 +40,9 @@ static const uint8_t sc121at_format_index[] = {
 #if CONFIG_CAMERA_SC121AT_MIPI_YUV422_1280X800_25FPS
     0,
 #endif
+#if CONFIG_CAMERA_SC121AT_MIPI_YUV422_1280X960_30FPS
+    1,
+#endif
 };
 
 static const esp_cam_sensor_format_t sc121at_format_info[] = {
@@ -57,6 +60,26 @@ static const esp_cam_sensor_format_t sc121at_format_info[] = {
         .isp_info = NULL,
         .mipi_info = {
             .mipi_clk = SC121AT_LINE_RATE_16BITS_1280x800_25FPS,
+            .lane_num = 2,
+            .line_sync_en = false,
+        },
+        .reserved = NULL,
+    },
+#endif
+#if CONFIG_CAMERA_SC121AT_MIPI_YUV422_1280X960_30FPS
+    {
+        .name = "MIPI_2lane_24Minput_YUV422_UYVY_1280x960_30fps",
+        .format = ESP_CAM_SENSOR_PIXFORMAT_YUV422_UYVY,
+        .port = ESP_CAM_SENSOR_MIPI_CSI,
+        .xclk = 24000000,
+        .width = 1280,
+        .height = 960,
+        .regs = sc121at_mipi_2lane_24Minput_1280x960_yuv422_30fps,
+        .regs_size = ARRAY_SIZE(sc121at_mipi_2lane_24Minput_1280x960_yuv422_30fps),
+        .fps = 30,
+        .isp_info = NULL,
+        .mipi_info = {
+            .mipi_clk = SC121AT_LINE_RATE_16BITS_1280x960_30FPS,
             .lane_num = 2,
             .line_sync_en = false,
         },


### PR DESCRIPTION
## Description

This PR adds support for a new video format configuration for the SC121AT camera sensor: **1280x960 resolution at 30fps** with YUV422(UYVY) color format.

**Changes include:**
- Added new Kconfig option `CAMERA_SC121AT_MIPI_YUV422_1280X960_30FPS` to enable the new format
- Created register configuration file for the new 1280x960@30fps mode
- Updated format arrays and indices to support the new resolution
- Set 1280x960@30fps as the new default format (previously 1280x800@25fps)

**Motivation:**
The 1280x960 resolution provides a standard 4:3 aspect ratio with higher vertical resolution compared to the existing 1280x800 format, which is beneficial for applications requiring more vertical field of view while maintaining the same horizontal resolution.

## Related

- Related to SC121AT sensor driver improvements
- Follows the same pattern as existing SC101 480p support (commit 3b22356)

## Testing

- [ ] Verified that the new format can be selected via menuconfig
- [ ] Tested with SC121AT sensor hardware to confirm 1280x960@30fps output
- [ ] Confirmed backward compatibility - existing 1280x800@25fps format still available
- [ ] Verified MIPI CSI interface configuration with 2-lane, 24MHz input clock
- [ ] Checked that the register settings produce stable video stream

**Test environment:**
- Platform: ESP32-P4
- Sensor: SC121AT
- Interface: MIPI CSI (2-lane)

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

---

## Technical Details

**Files modified:**
1. `Kconfig.sc121at` - Added new format option and made it default
2. `sc121at_mipi_2lane_24Minput_1280x960_yuv422_uyvy_30fps.h` - New register configuration
3. `sc121at_settings.h` - Added clock rate and line rate definitions
4. `sc121at.c` - Updated format arrays to include new resolution

**Register changes:**
- `0x3222 = 0x00`
- `0x500f = 0x30`

**MIPI parameters:**
- Clock rate: 59MHz (same as 1280x800@25fps)
- Line rate: 472Mbps (59MHz × 8)
- Data lanes: 2
- Line sync: disabled
